### PR TITLE
Fix issues with discord auth after the env variables were changed

### DIFF
--- a/packages/client/src/utils/discordSDK.ts
+++ b/packages/client/src/utils/discordSDK.ts
@@ -9,7 +9,7 @@ let discordSdk: DiscordSDK | DiscordSDKMock;
 
 const initiateDiscordSDK = async () => {
   if (isEmbedded) {
-    discordSdk = new DiscordSDK(import.meta.env.VITE_CLIENT_ID);
+    discordSdk = new DiscordSDK(import.meta.env.VITE_DISCORD_CLIENT_ID);
     await discordSdk.ready();
   } else {
     // We're using session storage for user_id, guild_id, and channel_id
@@ -22,7 +22,7 @@ const initiateDiscordSDK = async () => {
     const mockGuildId = getOverrideOrRandomSessionValue("guild_id");
     const mockChannelId = getOverrideOrRandomSessionValue("channel_id");
 
-    discordSdk = new DiscordSDKMock(import.meta.env.VITE_CLIENT_ID, mockGuildId, mockChannelId);
+    discordSdk = new DiscordSDKMock(import.meta.env.VITE_DISCORD_CLIENT_ID, mockGuildId, mockChannelId);
     const discriminator = String(mockUserId.charCodeAt(0) % 5);
 
     discordSdk._updateCommandMocks({
@@ -57,7 +57,7 @@ const authorizeDiscordUser = async () => {
   }
 
   const { code } = await discordSdk.commands.authorize({
-    client_id: import.meta.env.VITE_CLIENT_ID,
+    client_id: import.meta.env.VITE_DISCORD_CLIENT_ID,
     response_type: "code",
     state: "",
     prompt: "none",

--- a/packages/server/environment.d.ts
+++ b/packages/server/environment.d.ts
@@ -1,8 +1,8 @@
 declare global {
     namespace NodeJS {
       interface ProcessEnv {
-        VITE_CLIENT_ID: string;
-        CLIENT_SECRET: string;
+        VITE_DISCORD_CLIENT_ID: string;
+        DISCORD_CLIENT_SECRET: string;
         NODE_ENV: 'development' | 'production';
         PORT?: string;
         PWD: string;

--- a/packages/server/src/server.ts
+++ b/packages/server/src/server.ts
@@ -41,8 +41,8 @@ router.use("/colyseus", monitor(server as Partial<MonitorOptions>));
 // Fetch token from developer portal and return to the embedded app
 router.post("/api/token", async (req: Request, res: Response) => {
   let b = new URLSearchParams({
-    client_id: process.env.VITE_CLIENT_ID,
-    client_secret: process.env.CLIENT_SECRET,
+    client_id: process.env.VITE_DISCORD_CLIENT_ID,
+    client_secret: process.env.DISCORD_CLIENT_SECRET,
     grant_type: "authorization_code",
     code: req.body.code,
   });
@@ -53,8 +53,8 @@ router.post("/api/token", async (req: Request, res: Response) => {
       "Content-Type": "application/x-www-form-urlencoded",
     },
     body: new URLSearchParams({
-      client_id: process.env.VITE_CLIENT_ID,
-      client_secret: process.env.CLIENT_SECRET,
+      client_id: process.env.VITE_DISCORD_CLIENT_ID,
+      client_secret: process.env.DISCORD_CLIENT_SECRET,
       grant_type: "authorization_code",
       code: req.body.code,
     }),


### PR DESCRIPTION
I was running into the issue mentioned in #8. And after messing around locally, I believe this fixes the issue that came up due to 397ae370224168dd3c6cccc586719d28bb3232f9